### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Timesheet Manager is a pnpm workspace monorepo with two apps:
+
+| App | Path | Port | Framework |
+|-----|------|------|-----------|
+| API | `apps/api` | 3000 | NestJS + TypeORM |
+| Web | `apps/web` | 5173 | Vue 3 + Vite |
+
+PostgreSQL 16 runs in Docker on host port **5433** (not the default 5432).
+
+### Starting services
+
+1. **Database**: `pnpm db:up` (Docker Compose, requires Docker daemon running)
+2. **Migrations + seed + both servers**: `pnpm dev` (or equivalently `pnpm demo`)
+3. Alternatively start services individually:
+   - `pnpm --filter api dev` (NestJS watch mode, port 3000)
+   - `pnpm --filter web dev` (Vite dev server, port 5173)
+
+The API global prefix is `/api/v1`. Health check: `GET /api/v1/health`.
+
+### Docker daemon
+
+In Cloud Agent VMs, Docker runs inside a container. The daemon must be started manually:
+
+```sh
+dockerd &>/var/log/dockerd.log &
+sleep 3
+```
+
+The environment uses `fuse-overlayfs` storage driver and `iptables-legacy`.
+
+### Seeded demo accounts
+
+| Role | Email | Password |
+|------|-------|----------|
+| Employee | employee@example.com | password123 |
+| Approver | approver@example.com | password123 |
+| Admin | admin@example.com | password123 |
+
+### Testing
+
+See `README.md` for the full command list. Quick reference:
+
+- **Lint**: `pnpm lint`
+- **Typecheck**: `pnpm typecheck`
+- **Format check**: `pnpm format:check`
+- **All static checks**: `pnpm static`
+- **Unit tests**: `pnpm test` (runs both API Jest + Web Vitest)
+- **API integration tests**: `pnpm --filter api test:integration` (requires running DB)
+- **E2E tests**: `pnpm --filter web test:e2e` (requires full stack running)
+
+### Pre-commit hook
+
+The `.husky/pre-commit` hook runs `pnpm lint && pnpm typecheck`. Ensure these pass before committing.
+
+### Environment variables
+
+The API loads `.env.example` as fallback when `NODE_ENV !== 'production'`, so no manual `.env` file is needed for local dev. See `apps/api/.env.example` for all available variables.
+
+### Gotchas
+
+- The `pnpm-workspace.yaml` includes `onlyBuiltDependencies` for `bcrypt`, `@nestjs/core`, and `esbuild` to avoid interactive `pnpm approve-builds` prompts.
+- TypeORM `synchronize: true` is never used; always create proper migrations via `pnpm --filter api migration:generate`.
+- The web app proxies API calls in dev via Vite config — no CORS issues when running both locally.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment setup instructions for Cursor Cloud agents.

## What's included

- Service overview table (API, Web, PostgreSQL)
- How to start services (`pnpm dev` or individually)
- Docker daemon startup instructions for Cloud VMs
- Seeded demo account credentials
- Testing commands (lint, typecheck, unit, integration, e2e)
- Pre-commit hook details
- Environment variable notes
- Common gotchas (onlyBuiltDependencies, TypeORM migrations, Vite proxy)

## Environment verification

All checks pass:

- **Lint**: `pnpm lint` — clean
- **Typecheck**: `pnpm typecheck` — clean
- **Format**: `pnpm format:check` — clean
- **Unit tests**: `pnpm test` — 8 tests passed (4 API + 4 Web)
- **API server**: running on port 3000, health check OK
- **Web server**: running on port 5173, Vite dev server serving Vue app
- **Hello-world**: logged in as employee, created timesheet with 2 entries via API

## Demo

[demo_timesheet_manager.mp4](https://cursor.com/agents/bc-4eeda828-de65-4abc-84d6-84bc6eb911fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_timesheet_manager.mp4)

[Dashboard after login](https://cursor.com/agents/bc-4eeda828-de65-4abc-84d6-84bc6eb911fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_after_login.webp)
[Project reporting page](https://cursor.com/agents/bc-4eeda828-de65-4abc-84d6-84bc6eb911fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fproject_reporting.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4eeda828-de65-4abc-84d6-84bc6eb911fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4eeda828-de65-4abc-84d6-84bc6eb911fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

